### PR TITLE
fix: ensure type safety for m2m elements in laboratories

### DIFF
--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -70,7 +70,7 @@ export const Schema = object({
 	students_organizations_directus_files: StudentsOrganizationsDirectusFiles,
 	students_organizations_overview: StudentsOrganizationsOverview,
 	students_overview: StudentsOverview,
-	students_pages: StudentsPages,
+	students_pages: StudentsPages
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/routes/research/labs/[slug]/+page.svelte
+++ b/website-frontend/src/routes/research/labs/[slug]/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	/** @type {import('./$types').PageData} */
 	import * as Carousel from '$lib/@shadcn-svelte/ui/carousel';
 	import FeaturedEventCard from '$lib/components/cards/FeaturedEventCard.svelte';
@@ -8,9 +8,13 @@
 	import PublicationCard from '$lib/components/cards/PublicationCard.svelte';
 	import PeopleCard from '$lib/components/cards/PeopleCard.svelte';
 	import CardPanel from '$lib/components/panel/CardPanel.svelte';
+	import { Laboratory } from '$lib/models/laboratories';
+	import { Publications } from '$lib/models/publications';
 
 	export let data;
-	const { laboratory, publications } = data;
+	let laboratory: Laboratory;
+	let publications: Publications;
+	$: ({ laboratory, publications } = data);
 
 	const background_images = laboratory.background_images
 		? laboratory.background_images
@@ -58,8 +62,8 @@
 							event_headline: e.event_headline,
 							hero_image: e.hero_image ?? '',
 							event_content: e.event_content,
-							start_date: e.start_date,
-							end_date: e.end_date,
+							start_date: e.start_date as 'datetime',
+							end_date: e.end_date as 'datetime',
 							event_area: e.event_area,
 							display_location: e.display_location,
 							tags: e.tags,

--- a/website-frontend/src/routes/research/labs/[slug]/+page.ts
+++ b/website-frontend/src/routes/research/labs/[slug]/+page.ts
@@ -1,0 +1,7 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ data }) {
+	return {
+		laboratory: data.laboratory,
+		publications: data.publications
+	};
+}


### PR DESCRIPTION
 This PR ensures type safety for m2m elements in laboratories, which are accessed inside `+page.svelte`. However, it should be noted that this fix is only temporary, and a production-level solution should be applied in a future PR.